### PR TITLE
Fix IbmTerraform RefreshWorker settings name

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/refresh_worker.rb
@@ -1,7 +1,3 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::RefreshWorker < MiqEmsRefreshWorker
   require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_cam_configuration
-  end
 end


### PR DESCRIPTION
The settings name was still overridden as cam_configuration instead of ibm_terraform_configuration which was causing a missing config section error

https://travis-ci.com/github/ManageIQ/manageiq/jobs/378106440#L706