### PR TITLE
Link Configured Systems with discovered VMs.

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -42,7 +42,7 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
     collector.virtual_machines.each do |virtual_machine|
       virtual_instance_ref = virtual_machine["idFromProvider"]
       counterpart          = persister.vms.lazy_find(virtual_instance_ref) if virtual_instance_ref
-      
+
       persister.configured_systems.build(
         :manager_ref          => virtual_machine["id"].to_s,
         :name                 => virtual_machine["name"],

--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -40,11 +40,13 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
   # }]
   def configured_systems
     collector.virtual_machines.each do |virtual_machine|
+      virtual_instance_ref = virtual_machine["idFromProvider"].to_s
       persister.configured_systems.build(
         :manager_ref          => virtual_machine["id"].to_s,
         :name                 => virtual_machine["name"],
         :ipaddress            => virtual_machine["ipaddresses"]&.first,
-        :virtual_instance_ref => virtual_machine["idFromProvider"]
+        :virtual_instance_ref => virtual_instance_ref,
+        :counterpart          => persister.vms.lazy_find(virtual_instance_ref)
       )
     end
   end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -40,13 +40,15 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
   # }]
   def configured_systems
     collector.virtual_machines.each do |virtual_machine|
-      virtual_instance_ref = virtual_machine["idFromProvider"].to_s
+      virtual_instance_ref = virtual_machine["idFromProvider"]
+      counterpart          = persister.vms.lazy_find(virtual_instance_ref) if virtual_instance_ref
+      
       persister.configured_systems.build(
         :manager_ref          => virtual_machine["id"].to_s,
         :name                 => virtual_machine["name"],
         :ipaddress            => virtual_machine["ipaddresses"]&.first,
         :virtual_instance_ref => virtual_instance_ref,
-        :counterpart          => persister.vms.lazy_find(virtual_instance_ref)
+        :counterpart          => counterpart
       )
     end
   end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/persister/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/persister/configuration_manager.rb
@@ -2,5 +2,18 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Persister::ConfigurationMana
   def initialize_inventory_collections
     add_collection(configuration, :configuration_profiles)
     add_collection(configuration, :configured_systems)
+
+    add_cross_provider_vms
+  end
+
+  def add_cross_provider_vms
+    add_collection(configuration, :vms) do |builder|
+      builder.add_properties(
+        :parent      => nil,
+        :arel        => Vm,
+        :strategy    => :local_db_find_references,
+        :manager_ref => %i[uid_ems]
+      )
+    end
   end
 end

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -4,6 +4,8 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
   end
 
   context "#refresh" do
+    let!(:cross_link_vm) { FactoryBot.create(:vm, :ems_ref => "i-0361c15366e550109", :uid_ems => "i-0361c15366e550109") }
+
     let(:provider) do
       url = Rails.application.secrets.cam.try(:[], :url) || 'cam_url'
       identity_url = Rails.application.secrets.cam.try(:[], :identity_url) || 'identity_url'
@@ -51,6 +53,8 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
         :type     => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem",
         :hostname => "aws_instance.orpheus_ubuntu_micro"
       )
+
+      expect(configured_system.counterpart).to eq(cross_link_vm)
     end
   end
 end


### PR DESCRIPTION
Link the Configured Systems(vms discovered from CAM) with the resources discovered by ManageIQ using different Compute providers.