### PR TITLE
Add target platform to configuration profile

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -7,9 +7,10 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
   def configuration_profiles
     collector.templates.each do |template|
       persister.configuration_profiles.build(
-        :manager_ref => template["id"].to_s,
-        :name        => template["name"],
-        :description => template["description"]
+        :manager_ref     => template["id"].to_s,
+        :name            => template["name"],
+        :description     => template["description"],
+        :target_platform => template.dig("manifest", "template_provider")
       )
     end
   end

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -41,9 +41,10 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
     def assert_specific_configuration_profile
       configuration_profile = ems.configuration_profiles.find_by(:manager_ref => "5d2f6030c068e4001c9bfbb7")
       expect(configuration_profile).to have_attributes(
-        :type        => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProfile",
-        :name        => "LAMP stack deployment on AWS",
-        :description => "LAMP - A fully-integrated environment for full stack PHP web development.",
+        :type            => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProfile",
+        :name            => "LAMP stack deployment on AWS",
+        :description     => "LAMP - A fully-integrated environment for full stack PHP web development.",
+        :target_platform => "Amazon EC2"
       )
     end
 


### PR DESCRIPTION
Add the template cloud provider in the configuration profile as `target_platform`.