### PR TITLE
set the zone_id for the configuration manager

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::IbmTerraform::ConfigurationManager < ManageIQ::Provid
            :endpoints=,
            :url,
            :url=,
+           :name=,
            :verify_credentials,
            :with_provider_connection,
            :to => :provider
@@ -42,34 +43,6 @@ class ManageIQ::Providers::IbmTerraform::ConfigurationManager < ManageIQ::Provid
   def self.display_name(number = 1)
     n_('Configuration Manager (IBM Terraform)', 'Configuration Managers (IBM Terraform)', number)
   end
-
-  def self.create_from_params(params, endpoints, authentications)
-    new(params).tap do |ems|
-      endpoints.each { |endpoint| ems.assign_nested_endpoint(endpoint) }
-      authentications.each { |authentication| ems.assign_nested_authentication(authentication) }
-
-      ems.provider.save!
-      ems.save!
-    end
-  end
-
-  def edit_with_params(params, endpoints, authentications)
-    tap do |ems|
-      transaction do
-        # Remove endpoints/attributes that are not arriving in the arguments above
-        ems.endpoints.where.not(:role => nil).where.not(:role => endpoints.map { |ep| ep['role'] }).delete_all
-        ems.authentications.where.not(:authtype => nil).where.not(:authtype => authentications.map { |au| au['authtype'] }).delete_all
-
-        ems.assign_attributes(params)
-        ems.endpoints = endpoints.map(&method(:assign_nested_endpoint))
-        ems.authentications = authentications.map(&method(:assign_nested_authentication))
-
-        ems.provider.save!
-        ems.save!
-      end
-    end
-  end
-  delegate :name=, :zone, :zone=, :zone_id, :zone_id=, :to => :provider
 
   def name
     "#{provider.name} Configuration Manager"

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_manager_spec.rb
@@ -1,0 +1,54 @@
+describe ManageIQ::Providers::IbmTerraform::ConfigurationManager do
+  before { EvmSpecHelper.create_guid_miq_server_zone }
+
+  let(:zone) { FactoryBot.create(:zone) }
+  let(:params) { {:name => "IbmTerraform for test", :zone_id => zone.id} }
+  let(:endpoints) do
+    [
+      {"role" => "default", "url" => "https://cam.dev.multicloudops.io", "verify_ssl" => 0},
+      {"role" => "identity", "url" => "https://cp-console.dev.multicloudops.io", "verify_ssl" => 0},
+    ]
+  end
+  let(:authentications) do
+    [{"authtype" => "default", "userid" => "admin", "password" => "password"}]
+  end
+
+  describe "create configuration manager tests" do
+    it "#create_from_params test" do
+      config_manager = described_class.create_from_params(params, endpoints, authentications)
+
+      # verify the configuration manager and the provider are created properly
+      expect(config_manager.name).to eq("IbmTerraform for test Configuration Manager")
+      expect(config_manager.zone_id).to eq(zone.id)
+
+      expect(config_manager.provider.name).to eq("IbmTerraform for test")
+      expect(config_manager.provider.endpoints.count).to eq(2)
+
+      # verify the configuration manager can be found in db by zone_id
+      expect(described_class.where(:zone_id => zone.id)).to exist
+    end
+  end
+
+  describe "update configuration manager tests" do
+    let(:ems) { described_class.create_from_params(params, endpoints, authentications) }
+    let(:provider) { ems.provider }
+
+    it "#edit_with_params test" do
+      provider_name = "IbmTerraform2"
+      params = {:name => provider_name, :zone_id => zone.id}
+      endpoints = [
+        {"role" => "default", "url" => "https://cam.dev.multicloudops.io", "verify_ssl" => 0},
+        {"role" => "identity", "url" => "https://cp-console.dev.multicloudops.io", "verify_ssl" => 0},
+      ]
+      authentications = [
+        {"authtype" => "default", "userid" => "admin", "password" => "password"}
+      ]
+
+      ems.edit_with_params(params, endpoints, authentications)
+      provider.reload
+
+      expect(provider.name).to eq(provider_name)
+      expect(ems.zone_id).to eq(zone.id)
+    end
+  end
+end


### PR DESCRIPTION
EMS worker mixin uses the ConfigurationManager.where(:zone_id => zone_id) method to find the managers in a specific zone.
We need to have the `zone_id` properly set in the `configuration_manager` table.