### PR TITLE
Add configured systems link to configuration profiles

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/inventory/collector/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/collector/configuration_manager.rb
@@ -13,7 +13,10 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Collector::ConfigurationMana
     @virtual_machines ||= begin
       iaas_resource_virtual_machine_uri = URI.parse(manager.url)
       iaas_resource_virtual_machine_uri.path = "/cam/api/v1/iaasresources"
-      iaas_resource_virtual_machine_uri.query = URI.encode_www_form("filter" => '{"where": {"type": "virtual_machine"}}', "tenantId" => tenant_id, "ace_orgGuid" => "all")
+      iaas_resource_virtual_machine_uri.query = URI.encode_www_form(
+        "filter" => '{"where": {"type": "virtual_machine"}, "include": {"relation": "stacks"}}',
+        "tenantId" => tenant_id, "ace_orgGuid" => "all"
+      )
       response = redirect_cam_api(iaas_resource_virtual_machine_uri)
       JSON.parse(response.body)
     end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -33,6 +33,9 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
   #         "18.215.xxx.yyy",
   #         "172.31.xx.yy"
   #     ],
+  #     "stacks": {
+  #         "templateId": "5ee8ddde6143d40017c2ee46"
+  #     },
   #     "tainted": false,
   #     "tenantId": "fbb9ab6a-b54d-43d4-9200-6d950700588f",
   #     "namespaceId": "acme",
@@ -41,15 +44,18 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
   # }]
   def configured_systems
     collector.virtual_machines.each do |virtual_machine|
-      virtual_instance_ref = virtual_machine["idFromProvider"]
-      counterpart          = persister.vms.lazy_find(virtual_instance_ref) if virtual_instance_ref
+      virtual_instance_ref  = virtual_machine["idFromProvider"]
+      counterpart           = persister.vms.lazy_find(virtual_instance_ref) if virtual_instance_ref
+      template_id           = virtual_machine.dig("stacks", "templateId")
+      configuration_profile = persister.configuration_profiles.lazy_find(template_id.to_s) if template_id
 
       persister.configured_systems.build(
-        :manager_ref          => virtual_machine["id"].to_s,
-        :name                 => virtual_machine["name"],
-        :ipaddress            => virtual_machine["ipaddresses"]&.first,
-        :virtual_instance_ref => virtual_instance_ref,
-        :counterpart          => counterpart
+        :manager_ref           => virtual_machine["id"].to_s,
+        :name                  => virtual_machine["name"],
+        :ipaddress             => virtual_machine["ipaddresses"]&.first,
+        :virtual_instance_ref  => virtual_instance_ref,
+        :counterpart           => counterpart,
+        :configuration_profile => configuration_profile
       )
     end
   end

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -36,8 +36,8 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
         ems.reload
 
         assert_ems_counts
-        assert_specific_configuration_profile
-        assert_specific_configured_system
+        configuration_profile_id = assert_specific_configuration_profile
+        assert_specific_configured_system(configuration_profile_id)
       end
     end
 
@@ -54,13 +54,15 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
         :description     => "LAMP - A fully-integrated environment for full stack PHP web development.",
         :target_platform => "Amazon EC2"
       )
+      configuration_profile.id
     end
 
-    def assert_specific_configured_system
+    def assert_specific_configured_system(configuration_profile_id)
       configured_system = ems.configured_systems.find_by(:manager_ref => "5eac8d80ed4fa000171eaa23")
       expect(configured_system).to have_attributes(
-        :type     => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem",
-        :hostname => "aws_instance.orpheus_ubuntu_micro"
+        :type                     => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem",
+        :hostname                 => "aws_instance.orpheus_ubuntu_micro",
+        :configuration_profile_id => configuration_profile_id
       )
 
       expect(configured_system.counterpart).to eq(cross_link_vm)

--- a/spec/vcr_cassettes/manageiq/providers/ibm_terraform/configuration_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_terraform/configuration_manager/refresher.yml
@@ -191,7 +191,7 @@ http_interactions:
   recorded_at: Wed, 04 Mar 2020 16:29:36 GMT
 - request:
     method: get
-    uri: https://cam_url/cam/api/v1/iaasresources?ace_orgGuid=all&filter=%7B%22where%22:%20%7B%22type%22:%20%22virtual_machine%22%7D%7D&tenantId=f58e4d39-ac01-40fb-b259-88cd9a33f8e8
+    uri: https://cam_url/cam/api/v1/iaasresources?ace_orgGuid=all&filter=%7B%22where%22:%20%7B%22type%22:%20%22virtual_machine%22%7D,%20%22include%22:%20%7B%22relation%22:%20%22stacks%22%7D%7D&tenantId=f58e4d39-ac01-40fb-b259-88cd9a33f8e8
     body:
       encoding: US-ASCII
       string: ''
@@ -254,7 +254,7 @@ http_interactions:
       - Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With
     body:
       encoding: ASCII-8BIT
-      string: '[ { "type": "virtual_machine", "name": "aws_instance.orpheus_ubuntu_micro", "stackId": "5eac8d41ed4fa000171eaa1b", "provider": "Amazon EC2", "idFromProvider": "i-0361c15366e550109", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "172.88.10.15" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "eks-cluster-13", "namespaceMapping": true, "id": "5eac8d80ed4fa000171eaa23" }, { "type": "virtual_machine", "name": "aws_instance.db-server", "stackId": "5ee8dd8b6143d40017c2ee3c", "provider": "Amazon EC2", "idFromProvider": "i-01d992f6d1f8c04aa", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "18.212.88.88", "172.31.10.88" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "acme", "namespaceMapping": true, "id": "5ee8ddde6143d40017c2ee44" } ]'
+      string: '[ { "type": "virtual_machine", "name": "aws_instance.orpheus_ubuntu_micro", "stackId": "5eac8d41ed4fa000171eaa1b", "provider": "Amazon EC2", "idFromProvider": "i-0361c15366e550109", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "172.88.10.15" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "eks-cluster-13", "namespaceMapping": true, "id": "5eac8d80ed4fa000171eaa23", "stacks": { "templateId": "5d2f6030c068e4001c9bfbb7" } }, { "type": "virtual_machine", "name": "aws_instance.db-server", "stackId": "5ee8dd8b6143d40017c2ee3c", "provider": "Amazon EC2", "idFromProvider": "i-01d992f6d1f8c04aa", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "18.212.88.88", "172.31.10.88" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "acme", "namespaceMapping": true, "id": "5ee8ddde6143d40017c2ee44" } ]'
     http_version: null
   recorded_at: Wed, 04 Mar 2020 16:29:38 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
- Updated the virtual machines collector to retrieve the virtual machines with the parent stack details. The stack includes the `templateId` that maps to our configuration profile in manageiq.