### PR TITLE
Add vendor to the configured systems

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -53,6 +53,7 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
         :manager_ref           => virtual_machine["id"].to_s,
         :name                  => virtual_machine["name"],
         :ipaddress             => virtual_machine["ipaddresses"]&.first,
+        :vendor                => virtual_machine["provider"],
         :virtual_instance_ref  => virtual_instance_ref,
         :counterpart           => counterpart,
         :configuration_profile => configuration_profile

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -62,6 +62,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
       expect(configured_system).to have_attributes(
         :type                     => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem",
         :hostname                 => "aws_instance.orpheus_ubuntu_micro",
+        :vendor                   => "Amazon EC2",
         :configuration_profile_id => configuration_profile_id
       )
 


### PR DESCRIPTION
This is an enhancement required for https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/28. We want to  collect and display the cloud provider for each virtual machine.

<img width="593" alt="Screen Shot 2020-09-25 at 8 30 45 AM" src="https://user-images.githubusercontent.com/22264185/94267388-82a71d00-ff09-11ea-8b7b-400d1fa8bd4b.png">

