### PR TITLE
Set the hostname for the configured systems

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/inventory/collector/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/collector/configuration_manager.rb
@@ -13,10 +13,16 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Collector::ConfigurationMana
     @virtual_machines ||= begin
       iaas_resource_virtual_machine_uri = URI.parse(manager.url)
       iaas_resource_virtual_machine_uri.path = "/cam/api/v1/iaasresources"
+
+      filter = '{"where": {"type": "virtual_machine"},'\
+                '"fields": ["id", "name", "type", "idFromProvider", "stackId", "details", "ipaddresses", "provider"],'\
+                '"include": {"relation": "stacks", "scope": {"fields": ["templateId"]}}}'
       iaas_resource_virtual_machine_uri.query = URI.encode_www_form(
-        "filter" => '{"where": {"type": "virtual_machine"}, "include": {"relation": "stacks"}}',
-        "tenantId" => tenant_id, "ace_orgGuid" => "all"
+        "filter"      => filter,
+        "tenantId"    => tenant_id,
+        "ace_orgGuid" => "all"
       )
+
       response = redirect_cam_api(iaas_resource_virtual_machine_uri)
       JSON.parse(response.body)
     end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser/configuration_manager.rb
@@ -36,6 +36,9 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
   #     "stacks": {
   #         "templateId": "5ee8ddde6143d40017c2ee46"
   #     },
+  #     "details": {
+  #         "name": "demoinstance"
+  #     },
   #     "tainted": false,
   #     "tenantId": "fbb9ab6a-b54d-43d4-9200-6d950700588f",
   #     "namespaceId": "acme",
@@ -51,13 +54,26 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Parser::ConfigurationManager
 
       persister.configured_systems.build(
         :manager_ref           => virtual_machine["id"].to_s,
-        :name                  => virtual_machine["name"],
+        :name                  => get_hostname(virtual_machine),
         :ipaddress             => virtual_machine["ipaddresses"]&.first,
         :vendor                => virtual_machine["provider"],
         :virtual_instance_ref  => virtual_instance_ref,
         :counterpart           => counterpart,
         :configuration_profile => configuration_profile
       )
+    end
+  end
+
+  private
+
+  def get_hostname(virtual_machine)
+    vm_provider = virtual_machine["provider"]
+    if vm_provider == "Amazon EC2"
+      virtual_machine.dig("details", "tags.Name")
+    elsif vm_provider == "IBM"
+      virtual_machine.dig("details", "hostname")
+    else
+      virtual_machine.dig("details", "name")
     end
   end
 end

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -63,7 +63,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
       configured_system = ems.configured_systems.find_by(:manager_ref => "5eac8d80ed4fa000171eaa23")
       expect(configured_system).to have_attributes(
         :type                     => "ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem",
-        :hostname                 => "aws_instance.orpheus_ubuntu_micro",
+        :hostname                 => "demoinstance",
         :vendor                   => "Amazon EC2",
         :configuration_profile_id => configuration_profile_id
       )

--- a/spec/vcr_cassettes/manageiq/providers/ibm_terraform/configuration_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_terraform/configuration_manager/refresher.yml
@@ -191,7 +191,7 @@ http_interactions:
   recorded_at: Wed, 04 Mar 2020 16:29:36 GMT
 - request:
     method: get
-    uri: https://cam_url/cam/api/v1/iaasresources?ace_orgGuid=all&filter=%7B%22where%22:%20%7B%22type%22:%20%22virtual_machine%22%7D,%20%22include%22:%20%7B%22relation%22:%20%22stacks%22%7D%7D&tenantId=f58e4d39-ac01-40fb-b259-88cd9a33f8e8
+    uri: https://cam_url/cam/api/v1/iaasresources?ace_orgGuid=all&filter=%7B%22where%22:%20%7B%22type%22:%20%22virtual_machine%22%7D,%22fields%22:%20%5B%22id%22,%20%22name%22,%20%22type%22,%20%22idFromProvider%22,%20%22stackId%22,%20%22details%22,%20%22ipaddresses%22,%20%22provider%22%5D,%22include%22:%20%7B%22relation%22:%20%22stacks%22,%20%22scope%22:%20%7B%22fields%22:%20%5B%22templateId%22%5D%7D%7D%7D&tenantId=f58e4d39-ac01-40fb-b259-88cd9a33f8e8
     body:
       encoding: US-ASCII
       string: ''
@@ -254,7 +254,7 @@ http_interactions:
       - Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With
     body:
       encoding: ASCII-8BIT
-      string: '[ { "type": "virtual_machine", "name": "aws_instance.orpheus_ubuntu_micro", "stackId": "5eac8d41ed4fa000171eaa1b", "provider": "Amazon EC2", "idFromProvider": "i-0361c15366e550109", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "172.88.10.15" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "eks-cluster-13", "namespaceMapping": true, "id": "5eac8d80ed4fa000171eaa23", "stacks": { "templateId": "5d2f6030c068e4001c9bfbb7" } }, { "type": "virtual_machine", "name": "aws_instance.db-server", "stackId": "5ee8dd8b6143d40017c2ee3c", "provider": "Amazon EC2", "idFromProvider": "i-01d992f6d1f8c04aa", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "18.212.88.88", "172.31.10.88" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "acme", "namespaceMapping": true, "id": "5ee8ddde6143d40017c2ee44" } ]'
+      string: '[ { "type": "virtual_machine", "name": "aws_instance.orpheus_ubuntu_micro", "stackId": "5eac8d41ed4fa000171eaa1b", "provider": "Amazon EC2", "idFromProvider": "i-0361c15366e550109", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "172.88.10.15" ], "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "eks-cluster-13", "namespaceMapping": true, "id": "5eac8d80ed4fa000171eaa23", "stacks": { "templateId": "5d2f6030c068e4001c9bfbb7" }, "details": { "tags.Name": "demoinstance"} }, { "type": "virtual_machine", "name": "aws_instance.db-server", "stackId": "5ee8dd8b6143d40017c2ee3c", "provider": "Amazon EC2", "idFromProvider": "i-01d992f6d1f8c04aa", "typeFromProvider": "aws_instance", "module_path": [ "root" ], "consolelinks": [ "https://console.aws.amazon.com/ec2/v2/home" ], "ipaddresses": [ "18.212.88.88", "172.31.10.88" ], "details": { "tags.Name": "dbinstance"}, "tainted": false, "tenantId": "f58e4d39-ac01-40fb-b259-88cd9a33f8e8", "namespaceId": "acme", "namespaceMapping": true, "id": "5ee8ddde6143d40017c2ee44" } ]'
     http_version: null
   recorded_at: Wed, 04 Mar 2020 16:29:38 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
We need to properly set the hostname in the configured systems when we collect the virtual machines from CAM. The proper hostname of the virtual machine is one of the attributes in the iaasresource details object. The attribute name depends on the provider: AWS uses `tags.Name`, IBM Cloud uses `hostname`, while all the other cloud providers use `name`.

Related to: https://github.com/ManageIQ/manageiq-providers-ibm_terraform/issues/28