### PR TITLE
Fix template details link

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
@@ -3,6 +3,6 @@ class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProf
 
   def console_url
     base_url = provider.default_endpoint.url
-    "#{base_url}/templates/#!/templatedetails/#{manager_ref}"
+    "#{base_url}/cam/templates/#!/templatedetails/#{manager_ref}"
   end
 end

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -54,7 +54,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
         :description       => "LAMP - A fully-integrated environment for full stack PHP web development.",
         :target_platform   => "Amazon EC2",
         :supports_console? => true,
-        :console_url       => "https://#{url}/templates/#!/templatedetails/5d2f6030c068e4001c9bfbb7"
+        :console_url       => "https://#{url}/cam/templates/#!/templatedetails/5d2f6030c068e4001c9bfbb7"
       )
       configuration_profile.id
     end


### PR DESCRIPTION
The link to the CAM UI should use `/cam/templates/#!/templatedetails/{templateId}`