### PR TITLE
Add missing includes of the supports mixin

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProfile < ::ConfigurationProfile
+  include SupportsFeatureMixin
   supports :console
 
   def console_url

--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem < ::ConfiguredSystem
+  include SupportsFeatureMixin
   supports :console
 
   include ProviderObjectMixin


### PR DESCRIPTION
Fixes errors seen when spec/automated_review/ar_models_must_have_tables_spec.rb
is run in the core repository with rails 6:

```
NoMethodError:
  undefined method `supports' for #<Class:0x00007ffbb23f3120>
  Did you mean?  suppress
```