### PR TITLE
Refresh provider every 15.minutes

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,9 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+:ems_refresh:
+  :ibm_terraform:
+    :refresh_interval: 15.minutes
 :http_proxy:
   :ibm_terraform:
     :host:


### PR DESCRIPTION
Without an event catcher we should refresh relatively frequently, the default is once a day