### PR TITLE
Remove content runtime templates from discovery

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/inventory/collector/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/collector/configuration_manager.rb
@@ -3,7 +3,13 @@ class ManageIQ::Providers::IbmTerraform::Inventory::Collector::ConfigurationMana
     @templates ||= begin
       template_uri = URI.parse(manager.url)
       template_uri.path = "/cam/api/v1/templates"
-      template_uri.query = URI.encode_www_form("tenantId" => tenant_id, "ace_orgGuid" => "all")
+
+      filter = '{"where": {"type": {"neq": "ContentRuntime"}}}'
+      template_uri.query = URI.encode_www_form(
+        "filter"      => filter,
+        "tenantId"    => tenant_id,
+        "ace_orgGuid" => "all"
+      )
       response = redirect_cam_api(template_uri)
       JSON.parse(response.body)
     end

--- a/spec/vcr_cassettes/manageiq/providers/ibm_terraform/configuration_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_terraform/configuration_manager/refresher.yml
@@ -122,7 +122,7 @@ http_interactions:
   recorded_at: Wed, 04 Mar 2020 16:29:36 GMT
 - request:
     method: get
-    uri: https://cam_url/cam/api/v1/templates?ace_orgGuid=all&tenantId=f58e4d39-ac01-40fb-b259-88cd9a33f8e8
+    uri: https://cam_url/cam/api/v1/templates?ace_orgGuid=all&filter=%7B%22where%22:%20%7B%22type%22:%20%7B%22neq%22:%20%22ContentRuntime%22%7D%7D%7D&tenantId=f58e4d39-ac01-40fb-b259-88cd9a33f8e8
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
We currently discover all the templates from CAM and the collection includes the content runtime ones as well. We should remove these.