### PR TITLE
Drop gettext initializer

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ::Providers::IbmTerraform',
-  ManageIQ::Providers::IbmTerraform::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
The initializer is not needed, since catalogs are part of core.

@miq-bot add_label cleanup