### PR TITLE
Do not memoize the params_for_create to fix the translation issues

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/provider.rb
+++ b/app/models/manageiq/providers/ibm_terraform/provider.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::IbmTerraform::Provider < ::Provider
   end
 
   def self.params_for_create
-    @params_for_create ||= {
+    {
       :fields => [
         {
           :component => 'sub-form',
@@ -103,7 +103,7 @@ class ManageIQ::Providers::IbmTerraform::Provider < ::Provider
           ],
         },
       ]
-    }.freeze
+    }
   end
 
   # Verify Credentials


### PR DESCRIPTION
Should fix i18n problems when switching languages cc @davidresende0

@miq-bot add_label i18n, bug, kasparov/yes?