### PR TITLE
Fix IBM Terraform refresh settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@
     :event_handling:
       :event_groups:
 :ems_refresh:
-  :ibm_terraform:
+  :ibm_terraform_configuration:
     :refresh_interval: 15.minutes
 :http_proxy:
   :ibm_terraform:


### PR DESCRIPTION
This fixes an issue where the the refresher was not using the configured refresh interval. The Settings was been retrieved using the ems type.