### PR TITLE
Add cpd-url to point to the cam UI

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProf
   supports :native_console
 
   def console_url
-    base_url = provider.default_endpoint.url
+    base_url = provider.cpd_endpoint.url
     "#{base_url}/cam/templates/#!/templatedetails/#{manager_ref}"
   end
 end

--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
@@ -1,8 +1,10 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProfile < ::ConfigurationProfile
-  supports :native_console
+  supports :native_console do
+    _('No Cloud Pak URL') if provider.cpd_endpoint.url.blank?
+  end
 
   def console_url
     base_url = provider.cpd_endpoint.url
-    "#{base_url}/cam/templates/#!/templatedetails/#{manager_ref}"
+    "#{base_url}/cam/templates/#!/templatedetails/#{manager_ref}" if base_url
   end
 end

--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem 
 
   def console_url
     if (stack_id = orchestration_stack&.ems_ref)
-      base_url = provider.default_endpoint.url
+      base_url = provider.cpd_endpoint.url
       "#{base_url}/cam/instances/#!/instanceDetails/#{stack_id}"
     end
   end

--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
@@ -1,5 +1,8 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem < ::ConfiguredSystem
-  supports :native_console
+  supports :native_console do
+    _('No Cloud Pak URL') if provider.cpd_endpoint.url.blank?
+  end
+
   include ProviderObjectMixin
 
   def provider_object(connection = nil)
@@ -15,10 +18,10 @@ class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem 
   end
 
   def console_url
-    if (stack_id = orchestration_stack&.ems_ref)
-      base_url = provider.cpd_endpoint.url
-      "#{base_url}/cam/instances/#!/instanceDetails/#{stack_id}"
-    end
+    base_url = provider.cpd_endpoint.url
+    stack_id = orchestration_stack&.ems_ref
+
+    "#{base_url}/cam/instances/#!/instanceDetails/#{stack_id}" if stack_id && base_url
   end
 
   private

--- a/app/models/manageiq/providers/ibm_terraform/provider.rb
+++ b/app/models/manageiq/providers/ibm_terraform/provider.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::IbmTerraform::Provider < ::Provider
            :url=,
            :to => :identity_endpoint, :prefix => "identity"
 
+  delegate :url,
+           :url=,
+           :to => :cpd_endpoint, :prefix => "cpd"
+
   virtual_column :url, :type => :string, :uses => :endpoints
 
   before_validation :ensure_managers
@@ -59,6 +63,15 @@ class ManageIQ::Providers::IbmTerraform::Provider < ::Provider
                   :id         => "endpoints.identity.url",
                   :label      => _("IBM Cloud Pak console"),
                   :helperText => _("IBM Cloud Pak console URL. e.g. https://cp-console.apps.mydomain.com"),
+                  :isRequired => true,
+                  :validate   => [{:type => "required"}]
+                },
+                {
+                  :component  => "text-field",
+                  :name       => "endpoints.cpd.url",
+                  :id         => "endpoints.cpd.url",
+                  :label      => _("IBM Cloud Pak url"),
+                  :helperText => _("IBM Cloud Pak URL. e.g. https://cpd-cp4waiops.apps.mydomain.com"),
                   :isRequired => true,
                   :validate   => [{:type => "required"}]
                 },
@@ -161,6 +174,11 @@ class ManageIQ::Providers::IbmTerraform::Provider < ::Provider
   def identity_endpoint
     identity_endpoint = endpoints.detect { |e| e.role == "identity" }
     identity_endpoint || endpoints.build(:role => "identity")
+  end
+
+  def cpd_endpoint
+    cpd_endpoint = endpoints.detect { |e| e.role == "cpd" }
+    cpd_endpoint || endpoints.build(:role => "cpd")
   end
 
   def connect(options = {})

--- a/app/models/manageiq/providers/ibm_terraform/provider.rb
+++ b/app/models/manageiq/providers/ibm_terraform/provider.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::IbmTerraform::Provider < ::Provider
                   :component  => "text-field",
                   :name       => "endpoints.cpd.url",
                   :id         => "endpoints.cpd.url",
-                  :label      => _("IBM Cloud Pak url"),
+                  :label      => _("IBM Cloud Pak URL"),
                   :helperText => _("IBM Cloud Pak URL. e.g. https://cpd-cp4waiops.apps.mydomain.com"),
                   :isRequired => true,
                   :validate   => [{:type => "required"}]

--- a/config/secrets.defaults.yml
+++ b/config/secrets.defaults.yml
@@ -3,6 +3,7 @@ test:
   ibm_terraform_defaults: &ibm_terraform_defaults
     url: cam-url
     identity_url: cam-identity-url
+    cpd_url: cam-cpd-url
     user: CAM_USER
     password: CAM_PASSWORD
   ibm_terraform:

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_manager_spec.rb
@@ -7,6 +7,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager do
     [
       {"role" => "default", "url" => "https://cam.dev.multicloudops.io", "verify_ssl" => 0},
       {"role" => "identity", "url" => "https://cp-console.dev.multicloudops.io", "verify_ssl" => 0},
+      {"role" => "cpd", "url" => "https://cpd-cp4waiops.dev.multicloudops.io", "verify_ssl" => 0},
     ]
   end
   let(:authentications) do
@@ -39,6 +40,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager do
       endpoints = [
         {"role" => "default", "url" => "https://cam.dev.multicloudops.io", "verify_ssl" => 0},
         {"role" => "identity", "url" => "https://cp-console.dev.multicloudops.io", "verify_ssl" => 0},
+        {"role" => "cpd", "url" => "https://cpd-cp4waiops.dev.multicloudops.io", "verify_ssl" => 0},
       ]
       authentications = [
         {"authtype" => "default", "userid" => "admin", "password" => "password"}

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_manager_spec.rb
@@ -23,7 +23,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager do
       expect(config_manager.zone_id).to eq(zone.id)
 
       expect(config_manager.provider.name).to eq("IbmTerraform for test")
-      expect(config_manager.provider.endpoints.count).to eq(2)
+      expect(config_manager.provider.endpoints.count).to eq(3)
 
       # verify the configuration manager can be found in db by zone_id
       expect(described_class.where(:zone_id => zone.id)).to exist

--- a/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_terraform/configuration_manager/refresher_spec.rb
@@ -13,11 +13,13 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
     let(:zone) { FactoryBot.create(:zone) }
     let(:params) { {:name => "IbmTerraform for test", :zone_id => zone.id} }
     let(:url) { Rails.application.secrets.ibm_terraform[:url] }
+    let(:cpd_url) { Rails.application.secrets.ibm_terraform[:cpd_url] }
     let(:endpoints) do
       identity_url = Rails.application.secrets.ibm_terraform[:identity_url]
       [
         {"role" => "default", "url" => "https://#{url}", "verify_ssl" => 0},
         {"role" => "identity", "url" => "https://#{identity_url}", "verify_ssl" => 0},
+        {"role" => "cpd", "url" => "https://#{cpd_url}", "verify_ssl" => 0},
       ]
     end
     let(:authentications) do
@@ -61,7 +63,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
         :name              => "LAMP stack deployment on AWS",
         :description       => "LAMP - A fully-integrated environment for full stack PHP web development.",
         :target_platform   => "Amazon EC2",
-        :console_url       => "https://#{url}/cam/templates/#!/templatedetails/5d2f6030c068e4001c9bfbb7"
+        :console_url       => "https://#{cpd_url}/cam/templates/#!/templatedetails/5d2f6030c068e4001c9bfbb7"
       )
       configuration_profile.id
     end
@@ -104,7 +106,7 @@ describe ManageIQ::Providers::IbmTerraform::ConfigurationManager::Refresher do
         :vendor                   => "Amazon EC2",
         :configuration_profile_id => configuration_profile_id,
         :orchestration_stack_id   => orchestration_stack_id,
-        :console_url              => "https://#{url}/cam/instances/#!/instanceDetails/5eac8d41ed4fa000171eaa1b"
+        :console_url              => "https://#{cpd_url}/cam/instances/#!/instanceDetails/5eac8d41ed4fa000171eaa1b"
       )
 
       expect(aws_configured_system.counterpart).to eq(cross_link_aws_vm)


### PR DESCRIPTION
presently we use `cam.apps.achania-341-01.cp.fyre.ibm.com` to redirect to cam pages from IM . But in cp4waiops the ui route has been changed and it should be `cpd-cp4waiops.apps.achania-341-01.cp.fyre.ibm.com` . so added a new field in ibm-terraform-provider for the user to enter cpd url and point console url to cpd url
Reference issue : https://github.ibm.com/katamari/dev-issue-tracking/issues/32642