### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configuration_profile.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfigurationProfile < ::ConfigurationProfile
-  supports :native_console do
+  supports :management_console do
     _('No Cloud Pak URL') if provider.cpd_endpoint.url.blank?
   end
 

--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/configured_system.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::ConfiguredSystem < ::ConfiguredSystem
-  supports :native_console do
+  supports :management_console do
     _('No Cloud Pak URL') if provider.cpd_endpoint.url.blank?
   end
 


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22474

Changes the feature name from native_console to management_console since native_console is already used by the RHV provider.