### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager.rb
@@ -1,10 +1,4 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager < ManageIQ::Providers::ConfigurationManager
-  require_nested :ConfigurationProfile
-  require_nested :ConfiguredSystem
-  require_nested :OrchestrationStack
-  require_nested :Refresher
-  require_nested :RefreshWorker
-
   include ProcessTasksMixin
   delegate :authentications,
            :authentications=,

--- a/app/models/manageiq/providers/ibm_terraform/configuration_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_terraform/configuration_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmTerraform::ConfigurationManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/ibm_terraform/inventory.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::IbmTerraform::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/collector.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/collector.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmTerraform::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :ConfigurationManager
 end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/parser.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmTerraform::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :ConfigurationManager
 end

--- a/app/models/manageiq/providers/ibm_terraform/inventory/persister.rb
+++ b/app/models/manageiq/providers/ibm_terraform/inventory/persister.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmTerraform::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :ConfigurationManager
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854